### PR TITLE
feat: 增加AI模型支持至16个

### DIFF
--- a/api/routes/ai.ts
+++ b/api/routes/ai.ts
@@ -7,26 +7,63 @@ const DEFAULT_MODELSCOPE_API_KEY = 'ms-85ed98e9-1a8e-41e5-8215-ee563559d069'
 
 // 支持的AI模型配置
 const AI_MODELS = {
+  // 通义千问系列
   qwen: {
     name: 'Qwen/Qwen3-235B-A22B-Instruct-2507',
     description: '通义千问大模型，适合中文推荐文案生成'
   },
+  'qwen2.5-7b': {
+    name: 'Qwen/Qwen2.5-7B-Instruct',
+    description: 'Qwen 2.5 7B，轻量快速响应'
+  },
+  'qwen2.5-72b': {
+    name: 'Qwen/Qwen2.5-72B-Instruct',
+    description: 'Qwen 2.5 72B，高性能模型'
+  },
+  'qwen2.5-coder-32b': {
+    name: 'Qwen/Qwen2.5-Coder-32B-Instruct',
+    description: 'Qwen 2.5 Coder，代码理解与生成'
+  },
+  'qwen2.5-vl-72b': {
+    name: 'Qwen/Qwen2.5-VL-72B-Instruct',
+    description: 'Qwen 2.5 VL 72B，多模态理解'
+  },
+  'qwen3-8b': {
+    name: 'Qwen/Qwen3-8B',
+    description: 'Qwen 3 8B，新一代轻量模型'
+  },
+  'qwen3-32b': {
+    name: 'Qwen/Qwen3-32B',
+    description: 'Qwen 3 32B，新一代中量模型'
+  },
+  // 书生系列
+  internlm: {
+    name: 'OpenGVLab/InternVL3_5-241B-A28B',
+    description: 'InternVL 3.5，多模态视觉理解'
+  },
+  // DeepSeek 系列
   'deepseek-v3.2': {
     name: 'deepseek-ai/DeepSeek-V3.2',
     description: 'DeepSeek V3.2，支持中文与推理'
   },
-  'deepseek-v3.1': {
-    name: 'deepseek-ai/DeepSeek-V3.1',
-    description: 'DeepSeek V3.1，通用对话与生成'
-  },
   'deepseek-r1-0528': {
     name: 'deepseek-ai/DeepSeek-R1-0528',
-    description: 'DeepSeek R1-0528，思维链与深度推理'
+    description: 'DeepSeek R1，思维链与深度推理'
   },
+  'deepseek-r1-distill-qwen-32b': {
+    name: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B',
+    description: 'DeepSeek R1 Distill，推理优化版本'
+  },
+  // MiniMax 系列
   'minimax-m1-80k': {
     name: 'MiniMax/MiniMax-M1-80k',
-    description: 'MiniMax M1-80k，大上下文窗口'
+    description: 'MiniMax M1，80k大上下文窗口'
   },
+  'minimax-m2.1': {
+    name: 'MiniMax/MiniMax-M2.1',
+    description: 'MiniMax M2.1，新版MiniMax模型'
+  },
+  // 专用模型
   'qwen-coder-480b': {
     name: 'Qwen/Qwen3-Coder-480B-A35B-Instruct',
     description: 'Qwen Coder 480B，代码理解与生成'

--- a/src/components/AIModelSelector.tsx
+++ b/src/components/AIModelSelector.tsx
@@ -8,20 +8,36 @@ import zhipuLogo from '@/assets/zhipu-color.svg';
 interface AIModelSelectorProps {
   currentModel:
     | 'qwen'
+    | 'qwen2.5-7b'
+    | 'qwen2.5-72b'
+    | 'qwen2.5-coder-32b'
+    | 'qwen2.5-vl-72b'
+    | 'qwen3-8b'
+    | 'qwen3-32b'
+    | 'internlm'
     | 'deepseek-v3.2'
-    | 'deepseek-v3.1'
     | 'deepseek-r1-0528'
+    | 'deepseek-r1-distill-qwen-32b'
     | 'minimax-m1-80k'
+    | 'minimax-m2.1'
     | 'qwen-coder-480b'
     | 'qwen-vl-235b'
     | 'glm-4.6v';
   onModelChange: (
     model:
       | 'qwen'
+      | 'qwen2.5-7b'
+      | 'qwen2.5-72b'
+      | 'qwen2.5-coder-32b'
+      | 'qwen2.5-vl-72b'
+      | 'qwen3-8b'
+      | 'qwen3-32b'
+      | 'internlm'
       | 'deepseek-v3.2'
-      | 'deepseek-v3.1'
       | 'deepseek-r1-0528'
+      | 'deepseek-r1-distill-qwen-32b'
       | 'minimax-m1-80k'
+      | 'minimax-m2.1'
       | 'qwen-coder-480b'
       | 'qwen-vl-235b'
       | 'glm-4.6v'
@@ -35,10 +51,18 @@ export const AIModelSelector = ({ currentModel, onModelChange }: AIModelSelector
   const models: Array<{
     id:
       | 'qwen'
+      | 'qwen2.5-7b'
+      | 'qwen2.5-72b'
+      | 'qwen2.5-coder-32b'
+      | 'qwen2.5-vl-72b'
+      | 'qwen3-8b'
+      | 'qwen3-32b'
+      | 'internlm'
       | 'deepseek-v3.2'
-      | 'deepseek-v3.1'
       | 'deepseek-r1-0528'
+      | 'deepseek-r1-distill-qwen-32b'
       | 'minimax-m1-80k'
+      | 'minimax-m2.1'
       | 'qwen-coder-480b'
       | 'qwen-vl-235b'
       | 'glm-4.6v';
@@ -47,14 +71,27 @@ export const AIModelSelector = ({ currentModel, onModelChange }: AIModelSelector
     logo?: string;
     color: string;
   }> = [
-    { id: 'qwen', name: '通义千问', description: '中文文案生成', logo: qwenLogo, color: 'text-blue-600' },
+    // 通义千问系列
+    { id: 'qwen', name: '通义千问 235B', description: '中文文案生成', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen2.5-7b', name: 'Qwen 2.5 7B', description: '轻量快速响应', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen2.5-72b', name: 'Qwen 2.5 72B', description: '高性能模型', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen2.5-coder-32b', name: 'Qwen 2.5 Coder', description: '代码理解', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen2.5-vl-72b', name: 'Qwen 2.5 VL 72B', description: '多模态理解', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen3-8b', name: 'Qwen 3 8B', description: '新一代轻量', logo: qwenLogo, color: 'text-blue-600' },
+    { id: 'qwen3-32b', name: 'Qwen 3 32B', description: '新一代中量', logo: qwenLogo, color: 'text-blue-600' },
     { id: 'qwen-coder-480b', name: 'Qwen Coder 480B', description: '代码理解与生成', logo: qwenLogo, color: 'text-blue-600' },
     { id: 'qwen-vl-235b', name: 'Qwen VL 235B', description: '多模态文本图像', logo: qwenLogo, color: 'text-blue-600' },
+    // 书生系列
+    { id: 'internlm', name: 'InternVL 3.5', description: '多模态视觉', color: 'text-emerald-600' },
+    // DeepSeek 系列
     { id: 'deepseek-v3.2', name: 'DeepSeek V3.2', description: '支持中文与推理', logo: deepseekLogo, color: 'text-purple-600' },
-    { id: 'deepseek-v3.1', name: 'DeepSeek V3.1', description: '通用对话与生成', logo: deepseekLogo, color: 'text-purple-600' },
-    { id: 'deepseek-r1-0528', name: 'DeepSeek R1-0528', description: '思维链与深度推理', logo: deepseekLogo, color: 'text-purple-600' },
-    { id: 'minimax-m1-80k', name: 'MiniMax M1-80k', description: '80k上下文窗口', logo: minimaxLogo, color: 'text-rose-600' },
-    { id: 'glm-4.6v', name: 'GLM-4.6V', description: '多模态与中文能力', logo: zhipuLogo, color: 'text-sky-600' }
+    { id: 'deepseek-r1-0528', name: 'DeepSeek R1', description: '思维链与深度推理', logo: deepseekLogo, color: 'text-purple-600' },
+    { id: 'deepseek-r1-distill-qwen-32b', name: 'DeepSeek R1 Distill', description: '推理优化版本', logo: deepseekLogo, color: 'text-purple-600' },
+    // MiniMax 系列
+    { id: 'minimax-m1-80k', name: 'MiniMax M1', description: '80k上下文窗口', logo: minimaxLogo, color: 'text-rose-600' },
+    { id: 'minimax-m2.1', name: 'MiniMax M2.1', description: '新版MiniMax', logo: minimaxLogo, color: 'text-rose-600' },
+    // 其他模型
+    { id: 'glm-4.6v', name: 'GLM-4.6V', description: '多模态与中文', logo: zhipuLogo, color: 'text-sky-600' }
   ];
 
   const currentModelInfo = models.find(m => m.id === currentModel);

--- a/src/services/backendAiService.ts
+++ b/src/services/backendAiService.ts
@@ -3,10 +3,18 @@ import { Recommendation } from '@/types';
 // 支持的AI模型类型
 type AIModel =
   | 'qwen'
+  | 'qwen2.5-7b'
+  | 'qwen2.5-72b'
+  | 'qwen2.5-coder-32b'
+  | 'qwen2.5-vl-72b'
+  | 'qwen3-8b'
+  | 'qwen3-32b'
+  | 'internlm'
   | 'deepseek-v3.2'
-  | 'deepseek-v3.1'
   | 'deepseek-r1-0528'
+  | 'deepseek-r1-distill-qwen-32b'
   | 'minimax-m1-80k'
+  | 'minimax-m2.1'
   | 'qwen-coder-480b'
   | 'qwen-vl-235b'
   | 'glm-4.6v';
@@ -16,11 +24,24 @@ class BackendAIService {
   private baseURL: string;
   private currentModel: AIModel;
   private AI_MODELS: Record<AIModel, { name: string }> = {
+    // 通义千问系列
     qwen: { name: 'Qwen/Qwen3-235B-A22B-Instruct-2507' },
+    'qwen2.5-7b': { name: 'Qwen/Qwen2.5-7B-Instruct' },
+    'qwen2.5-72b': { name: 'Qwen/Qwen2.5-72B-Instruct' },
+    'qwen2.5-coder-32b': { name: 'Qwen/Qwen2.5-Coder-32B-Instruct' },
+    'qwen2.5-vl-72b': { name: 'Qwen/Qwen2.5-VL-72B-Instruct' },
+    'qwen3-8b': { name: 'Qwen/Qwen3-8B' },
+    'qwen3-32b': { name: 'Qwen/Qwen3-32B' },
+    // 书生系列
+    internlm: { name: 'OpenGVLab/InternVL3_5-241B-A28B' },
+    // DeepSeek 系列
     'deepseek-v3.2': { name: 'deepseek-ai/DeepSeek-V3.2' },
-    'deepseek-v3.1': { name: 'deepseek-ai/DeepSeek-V3.1' },
     'deepseek-r1-0528': { name: 'deepseek-ai/DeepSeek-R1-0528' },
+    'deepseek-r1-distill-qwen-32b': { name: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B' },
+    // MiniMax 系列
     'minimax-m1-80k': { name: 'MiniMax/MiniMax-M1-80k' },
+    'minimax-m2.1': { name: 'MiniMax/MiniMax-M2.1' },
+    // 专用模型
     'qwen-coder-480b': { name: 'Qwen/Qwen3-Coder-480B-A35B-Instruct' },
     'qwen-vl-235b': { name: 'Qwen/Qwen3-VL-235B-A22B-Instruct' },
     'glm-4.6v': { name: 'ZhipuAI/GLM-4.6V' }
@@ -46,13 +67,18 @@ class BackendAIService {
     const models: AIModel[] = [
       this.currentModel,
       'qwen',
+      'qwen2.5-7b',
+      'qwen2.5-72b',
+      'qwen3-8b',
+      'qwen3-32b',
+      'internlm',
       'deepseek-v3.2',
-      'deepseek-v3.1',
       'deepseek-r1-0528',
+      'deepseek-r1-distill-qwen-32b',
       'minimax-m1-80k',
+      'minimax-m2.1',
       'qwen-coder-480b',
-      'qwen-vl-235b',
-      'glm-4.6v'
+      'qwen-vl-235b'
     ].filter((v, i, a) => a.indexOf(v as AIModel) === i) as AIModel[];
 
     for (let idx = 0; idx < models.length; idx++) {
@@ -121,10 +147,16 @@ class BackendAIService {
     const models: AIModel[] = [
       this.currentModel,
       'qwen',
+      'qwen2.5-7b',
+      'qwen2.5-72b',
+      'qwen3-8b',
+      'qwen3-32b',
+      'internlm',
       'deepseek-v3.2',
-      'deepseek-v3.1',
       'deepseek-r1-0528',
+      'deepseek-r1-distill-qwen-32b',
       'minimax-m1-80k',
+      'minimax-m2.1',
       'glm-4.6v'
     ].filter((v, i, a) => a.indexOf(v as AIModel) === i) as AIModel[];
 
@@ -194,10 +226,16 @@ class BackendAIService {
     const models: AIModel[] = [
       this.currentModel,
       'qwen',
+      'qwen2.5-7b',
+      'qwen2.5-72b',
+      'qwen3-8b',
+      'qwen3-32b',
+      'internlm',
       'deepseek-v3.2',
-      'deepseek-v3.1',
       'deepseek-r1-0528',
+      'deepseek-r1-distill-qwen-32b',
       'minimax-m1-80k',
+      'minimax-m2.1',
       'glm-4.6v'
     ].filter((v, i, a) => a.indexOf(v as AIModel) === i) as AIModel[];
 


### PR DESCRIPTION
## 概述

根据魔搭社区 (ModelScope) API 可用模型列表，将 AI 模型支持从 8 个扩展到 16 个。

## 变更内容

### 新增模型 (8个)

**Qwen 2.5 系列：**
- `qwen2.5-7b` - Qwen 2.5 7B，轻量快速响应
- `qwen2.5-72b` - Qwen 2.5 72B，高性能模型
- `qwen2.5-coder-32b` - Qwen 2.5 Coder，代码理解与生成
- `qwen2.5-vl-72b` - Qwen 2.5 VL 72B，多模态理解

**Qwen 3 系列：**
- `qwen3-8b` - Qwen 3 8B，新一代轻量模型
- `qwen3-32b` - Qwen 3 32B，新一代中量模型

**其他：**
- `internlm` - InternVL 3.5 (241B)，多模态视觉理解
- `deepseek-r1-distill-qwen-32b` - DeepSeek R1 Distill，推理优化版本
- `minimax-m2.1` - MiniMax M2.1，新版MiniMax模型

### 移除模型 (1个)

- ~~`deepseek-v3.1`~~ - 该模型已不在魔搭社区 API 列表中

### 保留模型

- `glm-4.6v` 暂时保留（用户可能有自定义配置）

## 技术细节

- 所有新增模型均已通过魔搭社区 API (`https://api-inference.modelscope.cn/v1/models`) 验证可用
- 更新了前端模型选择器、后端服务配置和 API 路由
- 更新了 fallback 模型列表，确保新模型在主模型失败时可用

## 测试

- 项目构建成功 (`npm run build`)
- 所有模型 API 名称均来自魔搭社区官方列表

## 关联 Issue

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>